### PR TITLE
removing redundant code.

### DIFF
--- a/lib/content-types/merge.js
+++ b/lib/content-types/merge.js
@@ -111,34 +111,6 @@ const squish = (types) => {
         if (attribute.required) {
           plugin.required = requiredLevel(attribute.required);
         }
-        if (attribute.repeatable) {
-          plugin.repeatable = attribute.repeatable;
-        }
-
-        // Organizes repeatable attributes
-        if (attribute.repeatable) {
-          if (typeof attribute.repeatable === 'object') {
-            plugin.repeatable = {};
-            if (!attribute.repeatable.hasOwnProperty('min')) {
-              plugin.repeatable.min = 1;
-            }
-            else {
-              plugin.repeatable.min = attribute.repeatable.min;
-            }
-            if (!attribute.repeatable.hasOwnProperty('max')) {
-              plugin.repeatable.max = Number.MAX_SAFE_INTEGER;
-            }
-            else {
-              plugin.repeatable.max = attribute.repeatable.max;
-            }
-          }
-          else if (attribute.repeatable === true) {
-            plugin.repeatable = {
-              min: 1,
-              max: Number.MAX_SAFE_INTEGER,
-            };
-          }
-        }
 
         plugin.id = attribute.id;
         plugin.type = attribute.type;
@@ -191,6 +163,7 @@ const squish = (types) => {
 
         // Sets inputs to min for repeatables
         if (attribute.repeatable) {
+          // Unifies the structure of repeatable
           if (typeof attribute.repeatable === 'object') {
             plugin.repeatable = {};
             if (!attribute.repeatable.hasOwnProperty('min')) {
@@ -212,6 +185,8 @@ const squish = (types) => {
               max: Number.MAX_SAFE_INTEGER,
             };
           }
+
+          // create instances equal to the value of min
           const pluginInputs = [];
           for (let i = 0; i < plugin.repeatable.min; i++) {
             const inputs = _.cloneDeep(plugin.inputs);


### PR DESCRIPTION
It was checking repeatables twice. Removed the first condition

`DCO 1.1 Signed-off-by: {{Ayush Gupta}} <{{ayush2k@gmail.com}}>`

