### PR TITLE
add description to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "punchcard-content-types",
-  "description": "Combines with input-plugin to create Content Types in the Punchcard CMS",
+  "description": "Combines with input plugins to create forms with validation. Creates forms for Punchcard CMS.",
   "main": "index.js",
   "version": "0.0.0",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "punchcard-content-types",
-  "description": "",
+  "description": "Combines with input-plugin to create Content Types in the Punchcard CMS",
   "main": "index.js",
   "version": "0.0.0",
   "keywords": [


### PR DESCRIPTION
this info is exposed on yarnpkg.com, npmjs.com and others. If it's not filled in, the first part of the readme is used (which causes duplication)

This info should also be in the GitHub repository description


`DCO 1.1 Signed-off-by: Haroen Viaene<hello@haroen.me>`
